### PR TITLE
optref, error, bytes, hex

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+#
+# Copyright Quadrivium LLC
+# All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+BasedOnStyle: Google
+
+AlignAfterOpenBracket: DontAlign
+AlignOperands: DontAlign
+AllowShortFunctionsOnASingleLine: Empty
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakStringLiterals: false
+DerivePointerAlignment: false
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+InsertBraces: true
+InsertTrailingCommas: Wrapped
+NamespaceIndentation: All
+PointerAlignment: Right
+QualifierAlignment: Custom
+QualifierOrder: ['inline', 'static', 'constexpr', 'const', 'volatile', 'type', 'restrict']
+ReferenceAlignment: Right
+ShortNamespaceLines: 0
+SortIncludes: CaseSensitive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+#
+# Copyright Quadrivium LLC
+# All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.12)
+
+cmake_policy(SET CMP0144 NEW)
+
+include(cmake/HunterGate.cmake)
+HunterGate(
+    URL  https://github.com/qdrvm/hunter/archive/refs/tags/v0.23.257-qdrvm11.tar.gz
+    SHA1 b2a69ae501bdc99006fb86e55930640004468556
+)
+
+project(qtils LANGUAGES CXX VERSION 0.0.1)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+include(GNUInstallDirs)
+
+hunter_add_package(Boost)
+find_package(Boost CONFIG REQUIRED)
+hunter_add_package(fmt)
+find_package(fmt CONFIG REQUIRED)
+
+add_library(qtils INTERFACE)
+target_link_libraries(qtils INTERFACE
+    Boost::boost
+    fmt::fmt
+)
+target_include_directories(qtils INTERFACE
+    $<BUILD_INTERFACE:src/qtils>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+install(DIRECTORY src/qtils
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.hpp"
+)
+install(TARGETS qtils EXPORT qtils-config)
+install(EXPORT qtils-config
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/qtils
+    NAMESPACE qtils::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-cmake_policy(SET CMP0144 NEW)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+    cmake_policy(SET CMP0144 NEW)
+endif()
 
 include(cmake/HunterGate.cmake)
 HunterGate(

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,0 +1,543 @@
+# Copyright (c) 2013-2019, Ruslan Baratov
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a gate file to Hunter package manager.
+# Include this file using `include` command and add package you need, example:
+#
+#     cmake_minimum_required(VERSION 3.5)
+#
+#     include("cmake/HunterGate.cmake")
+#     HunterGate(
+#         URL "https://github.com/path/to/hunter/archive.tar.gz"
+#         SHA1 "798501e983f14b28b10cda16afa4de69eee1da1d"
+#     )
+#
+#     project(MyProject)
+#
+#     hunter_add_package(Foo)
+#     hunter_add_package(Boo COMPONENTS Bar Baz)
+#
+# Projects:
+#     * https://github.com/hunter-packages/gate/
+#     * https://github.com/ruslo/hunter
+
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.5")
+    message(
+        FATAL_ERROR
+        "At least CMake version 3.5 required for Hunter dependency management."
+        " Update CMake or set HUNTER_ENABLED to OFF."
+    )
+  endif()
+endif()
+
+include(CMakeParseArguments) # cmake_parse_arguments
+
+option(HUNTER_STATUS_PRINT "Print working status" ON)
+option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
+set(HUNTER_ROOT "" CACHE FILEPATH "Override the HUNTER_ROOT.")
+
+set(HUNTER_ERROR_PAGE "https://hunter.readthedocs.io/en/latest/reference/errors")
+
+function(hunter_gate_status_print)
+  if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
+      message(STATUS "[hunter] ${print_message}")
+    endforeach()
+  endif()
+endfunction()
+
+function(hunter_gate_status_debug)
+  if(HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
+      string(TIMESTAMP timestamp)
+      message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
+    endforeach()
+  endif()
+endfunction()
+
+function(hunter_gate_error_page error_page)
+  message("------------------------------ ERROR ------------------------------")
+  message("    ${HUNTER_ERROR_PAGE}/${error_page}.html")
+  message("-------------------------------------------------------------------")
+  message("")
+  message(FATAL_ERROR "")
+endfunction()
+
+function(hunter_gate_internal_error)
+  message("")
+  foreach(print_message ${ARGV})
+    message("[hunter ** INTERNAL **] ${print_message}")
+  endforeach()
+  message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_error_page("error.internal")
+endfunction()
+
+function(hunter_gate_fatal_error)
+  cmake_parse_arguments(hunter "" "ERROR_PAGE" "" "${ARGV}")
+  if("${hunter_ERROR_PAGE}" STREQUAL "")
+    hunter_gate_internal_error("Expected ERROR_PAGE")
+  endif()
+  message("")
+  foreach(x ${hunter_UNPARSED_ARGUMENTS})
+    message("[hunter ** FATAL ERROR **] ${x}")
+  endforeach()
+  message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_error_page("${hunter_ERROR_PAGE}")
+endfunction()
+
+function(hunter_gate_user_error)
+  hunter_gate_fatal_error(${ARGV} ERROR_PAGE "error.incorrect.input.data")
+endfunction()
+
+function(hunter_gate_self root version sha1 result)
+  string(COMPARE EQUAL "${root}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("root is empty")
+  endif()
+
+  string(COMPARE EQUAL "${version}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("version is empty")
+  endif()
+
+  string(COMPARE EQUAL "${sha1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("sha1 is empty")
+  endif()
+
+  string(SUBSTRING "${sha1}" 0 7 archive_id)
+
+  if(EXISTS "${root}/cmake/Hunter")
+    set(hunter_self "${root}")
+  else()
+    set(
+        hunter_self
+        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+    )
+  endif()
+
+  set("${result}" "${hunter_self}" PARENT_SCOPE)
+endfunction()
+
+# Set HUNTER_GATE_ROOT cmake variable to suitable value.
+function(hunter_gate_detect_root)
+  # Check CMake variable
+  if(HUNTER_ROOT)
+    set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
+    return()
+  endif()
+
+  # Check environment variable
+  if(DEFINED ENV{HUNTER_ROOT})
+    set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
+    return()
+  endif()
+
+  # Check HOME environment variable
+  if(DEFINED ENV{HOME})
+    set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
+    return()
+  endif()
+
+  # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
+  if(WIN32)
+    if(DEFINED ENV{SYSTEMDRIVE})
+      set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
+      )
+      return()
+    endif()
+
+    if(DEFINED ENV{USERPROFILE})
+      set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using USERPROFILE environment variable"
+      )
+      return()
+    endif()
+  endif()
+
+  hunter_gate_fatal_error(
+      "Can't detect HUNTER_ROOT"
+      ERROR_PAGE "error.detect.hunter.root"
+  )
+endfunction()
+
+function(hunter_gate_download dir)
+  string(
+      COMPARE
+      NOTEQUAL
+      "$ENV{HUNTER_DISABLE_AUTOINSTALL}"
+      ""
+      disable_autoinstall
+  )
+  if(disable_autoinstall AND NOT HUNTER_RUN_INSTALL)
+    hunter_gate_fatal_error(
+        "Hunter not found in '${dir}'"
+        "Set HUNTER_RUN_INSTALL=ON to auto-install it from '${HUNTER_GATE_URL}'"
+        "Settings:"
+        "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
+        "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
+        ERROR_PAGE "error.run.install"
+    )
+  endif()
+  string(COMPARE EQUAL "${dir}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("Empty 'dir' argument")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_SHA1 empty")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_URL empty")
+  endif()
+
+  set(done_location "${dir}/DONE")
+  set(sha1_location "${dir}/SHA1")
+
+  set(build_dir "${dir}/Build")
+  set(cmakelists "${dir}/CMakeLists.txt")
+
+  hunter_gate_status_debug("Locking directory: ${dir}")
+  file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+  hunter_gate_status_debug("Lock done")
+
+  if(EXISTS "${done_location}")
+    # while waiting for lock other instance can do all the job
+    hunter_gate_status_debug("File '${done_location}' found, skip install")
+    return()
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(MAKE_DIRECTORY "${build_dir}") # check directory permissions
+
+  # Disabling languages speeds up a little bit, reduces noise in the output
+  # and avoids path too long windows error
+  file(
+      WRITE
+      "${cmakelists}"
+      "cmake_minimum_required(VERSION 3.5)\n"
+      "if(POLICY CMP0114)\n"
+      "  cmake_policy(SET CMP0114 NEW)\n"
+      "endif()\n"
+      "if(POLICY CMP0135)\n"
+      "  cmake_policy(SET CMP0135 NEW)\n"
+      "endif()\n"
+      "project(HunterDownload LANGUAGES NONE)\n"
+      "include(ExternalProject)\n"
+      "ExternalProject_Add(\n"
+      "    Hunter\n"
+      "    URL\n"
+      "    \"${HUNTER_GATE_URL}\"\n"
+      "    URL_HASH\n"
+      "    SHA1=${HUNTER_GATE_SHA1}\n"
+      "    DOWNLOAD_DIR\n"
+      "    \"${dir}\"\n"
+      "    TLS_VERIFY\n"
+      "    ${HUNTER_TLS_VERIFY}\n"
+      "    SOURCE_DIR\n"
+      "    \"${dir}/Unpacked\"\n"
+      "    CONFIGURE_COMMAND\n"
+      "    \"\"\n"
+      "    BUILD_COMMAND\n"
+      "    \"\"\n"
+      "    INSTALL_COMMAND\n"
+      "    \"\"\n"
+      ")\n"
+  )
+
+  if(HUNTER_STATUS_DEBUG)
+    set(logging_params "")
+  else()
+    set(logging_params OUTPUT_QUIET)
+  endif()
+
+  hunter_gate_status_debug("Run generate")
+
+  # Need to add toolchain file too.
+  # Otherwise on Visual Studio + MDD this will fail with error:
+  # "Could not find an appropriate version of the Windows 10 SDK installed on this machine"
+  if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    get_filename_component(absolute_CMAKE_TOOLCHAIN_FILE "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE)
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${absolute_CMAKE_TOOLCHAIN_FILE}")
+  else()
+    # 'toolchain_arg' can't be empty
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=")
+  endif()
+
+  string(COMPARE EQUAL "${CMAKE_MAKE_PROGRAM}" "" no_make)
+  if(no_make)
+    set(make_arg "")
+  else()
+    # Test case: remove Ninja from PATH but set it via CMAKE_MAKE_PROGRAM
+    set(make_arg "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+  endif()
+
+  execute_process(
+      COMMAND
+      "${CMAKE_COMMAND}"
+      "-H${dir}"
+      "-B${build_dir}"
+      "-G${CMAKE_GENERATOR}"
+      "${toolchain_arg}"
+      ${make_arg}
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error(
+        "Configure project failed."
+        "To reproduce the error run: ${CMAKE_COMMAND} -H${dir} -B${build_dir} -G${CMAKE_GENERATOR} ${toolchain_arg} ${make_arg}"
+        "In directory ${dir}"
+    )
+  endif()
+
+  hunter_gate_status_print(
+      "Initializing Hunter workspace (${HUNTER_GATE_SHA1})"
+      "  ${HUNTER_GATE_URL}"
+      "  -> ${dir}"
+  )
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" --build "${build_dir}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Build project failed")
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(WRITE "${sha1_location}" "${HUNTER_GATE_SHA1}")
+  file(WRITE "${done_location}" "DONE")
+
+  hunter_gate_status_debug("Finished")
+endfunction()
+
+# Must be a macro so master file 'cmake/Hunter' can
+# apply all variables easily just by 'include' command
+# (otherwise PARENT_SCOPE magic needed)
+macro(HunterGate)
+  if(HUNTER_GATE_DONE)
+    # variable HUNTER_GATE_DONE set explicitly for external project
+    # (see `hunter_download`)
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+
+  # First HunterGate command will init Hunter, others will be ignored
+  get_property(_hunter_gate_done GLOBAL PROPERTY HUNTER_GATE_DONE SET)
+
+  if(NOT HUNTER_ENABLED)
+    # Empty function to avoid error "unknown function"
+    function(hunter_add_package)
+    endfunction()
+
+    set(
+        _hunter_gate_disabled_mode_dir
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/disabled-mode"
+    )
+    if(EXISTS "${_hunter_gate_disabled_mode_dir}")
+      hunter_gate_status_debug(
+          "Adding \"disabled-mode\" modules: ${_hunter_gate_disabled_mode_dir}"
+      )
+      list(APPEND CMAKE_PREFIX_PATH "${_hunter_gate_disabled_mode_dir}")
+    endif()
+  elseif(_hunter_gate_done)
+    hunter_gate_status_debug("Secondary HunterGate (use old settings)")
+    hunter_gate_self(
+        "${HUNTER_CACHED_ROOT}"
+        "${HUNTER_VERSION}"
+        "${HUNTER_SHA1}"
+        _hunter_self
+    )
+    include("${_hunter_self}/cmake/Hunter")
+  else()
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
+    if(_have_project_name)
+      hunter_gate_fatal_error(
+          "Please set HunterGate *before* 'project' command. "
+          "Detected project: ${PROJECT_NAME}"
+          ERROR_PAGE "error.huntergate.before.project"
+      )
+    endif()
+
+    cmake_parse_arguments(
+        HUNTER_GATE "LOCAL" "URL;SHA1;GLOBAL;FILEPATH" "" ${ARGV}
+    )
+
+    string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" _empty_sha1)
+    string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" _empty_url)
+    string(
+        COMPARE
+        NOTEQUAL
+        "${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+        ""
+        _have_unparsed
+    )
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_GLOBAL}" "" _have_global)
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_FILEPATH}" "" _have_filepath)
+
+    if(_have_unparsed)
+      hunter_gate_user_error(
+          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+      )
+    endif()
+    if(_empty_sha1)
+      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
+    endif()
+    if(_empty_url)
+      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
+    endif()
+    if(_have_global)
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has GLOBAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has GLOBAL)")
+      endif()
+    endif()
+    if(HUNTER_GATE_LOCAL)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has LOCAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has LOCAL)")
+      endif()
+    endif()
+    if(_have_filepath)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has FILEPATH)")
+      endif()
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has FILEPATH)")
+      endif()
+    endif()
+
+    hunter_gate_detect_root() # set HUNTER_GATE_ROOT
+
+    # Beautify path, fix probable problems with windows path slashes
+    get_filename_component(
+        HUNTER_GATE_ROOT "${HUNTER_GATE_ROOT}" ABSOLUTE
+    )
+    hunter_gate_status_debug("HUNTER_ROOT: ${HUNTER_GATE_ROOT}")
+    if(NOT HUNTER_ALLOW_SPACES_IN_PATH)
+      string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
+      if(NOT _contain_spaces EQUAL -1)
+        hunter_gate_fatal_error(
+            "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
+            "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
+            "(Use at your own risk!)"
+            ERROR_PAGE "error.spaces.in.hunter.root"
+        )
+      endif()
+    endif()
+
+    string(
+        REGEX
+        MATCH
+        "[0-9]+\\.[0-9]+\\.[0-9]+[-_a-z0-9]*"
+        HUNTER_GATE_VERSION
+        "${HUNTER_GATE_URL}"
+    )
+    string(COMPARE EQUAL "${HUNTER_GATE_VERSION}" "" _is_empty)
+    if(_is_empty)
+      set(HUNTER_GATE_VERSION "unknown")
+    endif()
+
+    hunter_gate_self(
+        "${HUNTER_GATE_ROOT}"
+        "${HUNTER_GATE_VERSION}"
+        "${HUNTER_GATE_SHA1}"
+        _hunter_self
+    )
+
+    set(_master_location "${_hunter_self}/cmake/Hunter")
+    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
+      # Hunter downloaded manually (e.g. by 'git clone')
+      set(_unused "xxxxxxxxxx")
+      set(HUNTER_GATE_SHA1 "${_unused}")
+      set(HUNTER_GATE_VERSION "${_unused}")
+    else()
+      get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+      set(_done_location "${_archive_id_location}/DONE")
+      set(_sha1_location "${_archive_id_location}/SHA1")
+
+      # Check Hunter already downloaded by HunterGate
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_download("${_archive_id_location}")
+      endif()
+
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_internal_error("hunter_gate_download failed")
+      endif()
+
+      if(NOT EXISTS "${_sha1_location}")
+        hunter_gate_internal_error("${_sha1_location} not found")
+      endif()
+      file(READ "${_sha1_location}" _sha1_value)
+      string(TOLOWER "${_sha1_value}" _sha1_value_lower)
+      string(TOLOWER "${HUNTER_GATE_SHA1}" _HUNTER_GATE_SHA1_lower)
+      string(COMPARE EQUAL "${_sha1_value_lower}" "${_HUNTER_GATE_SHA1_lower}" _is_equal)
+      if(NOT _is_equal)
+        hunter_gate_internal_error(
+            "Short SHA1 collision:"
+            "  ${_sha1_value} (from ${_sha1_location})"
+            "  ${HUNTER_GATE_SHA1} (HunterGate)"
+        )
+      endif()
+      if(NOT EXISTS "${_master_location}")
+        hunter_gate_user_error(
+            "Master file not found:"
+            "  ${_master_location}"
+            "try to update Hunter/HunterGate"
+        )
+      endif()
+    endif()
+    include("${_master_location}")
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+endmacro()

--- a/src/qtils/bytecmp.hpp
+++ b/src/qtils/bytecmp.hpp
@@ -15,8 +15,9 @@ namespace qtils {
 
   auto operator<=>(const AsBytes auto &l_, const AsBytes auto &r_) {
     BytesIn l{l_}, r{r_};
-    auto c = l.size() <=> r.size();
-    return c != 0 ? c : std::memcmp(l.data(), r.data(), l.size()) <=> 0;
+    auto n = l.size() < r.size() ? l.size() : r.size();
+    auto c = std::memcmp(l.data(), r.data(), n) <=> 0;
+    return c != 0 ? c : l.size() <=> r.size();
   }
   bool operator==(const AsBytes auto &l_, const AsBytes auto &r_) {
     return (l_ <=> r_) == 0;

--- a/src/qtils/bytecmp.hpp
+++ b/src/qtils/bytecmp.hpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstring>
+#include <qtils/bytes.hpp>
+
+namespace qtils {
+  template <typename T>
+  concept AsBytes = requires(T t) { BytesIn{t}; };
+
+  auto operator<=>(const AsBytes auto &l_, const AsBytes auto &r_) {
+    BytesIn l{l_}, r{r_};
+    auto c = l.size() <=> r.size();
+    return c != 0 ? c : std::memcmp(l.data(), r.data(), l.size()) <=> 0;
+  }
+}  // namespace qtils
+
+using qtils::operator<=>;

--- a/src/qtils/bytecmp.hpp
+++ b/src/qtils/bytecmp.hpp
@@ -18,6 +18,10 @@ namespace qtils {
     auto c = l.size() <=> r.size();
     return c != 0 ? c : std::memcmp(l.data(), r.data(), l.size()) <=> 0;
   }
+  bool operator==(const AsBytes auto &l_, const AsBytes auto &r_) {
+    return (l_ <=> r_) == 0;
+  }
 }  // namespace qtils
 
 using qtils::operator<=>;
+using qtils::operator==;

--- a/src/qtils/bytes.hpp
+++ b/src/qtils/bytes.hpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace qtils {
+  using Bytes = std::vector<uint8_t>;
+  template <size_t N>
+  using BytesN = std::array<uint8_t, N>;
+  using BytesIn = std::span<const uint8_t>;
+  using BytesOut = std::span<uint8_t>;
+}  // namespace qtils

--- a/src/qtils/bytestr.hpp
+++ b/src/qtils/bytestr.hpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include <qtils/bytes.hpp>
+
+namespace qtils {
+  inline BytesIn str2byte(std::span<const char> s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {reinterpret_cast<const uint8_t *>(s.data()), s.size()};
+  }
+
+  inline std::string_view byte2str(const BytesIn &s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {reinterpret_cast<const char *>(s.data()), s.size()};
+  }
+}  // namespace qtils

--- a/src/qtils/cxx20/lexicographical_compare_three_way.hpp
+++ b/src/qtils/cxx20/lexicographical_compare_three_way.hpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#ifdef __APPLE__
+#include <compare>
+#include <type_traits>
+#else
+#include <algorithm>
+#endif
+
+namespace libp2p::cxx20 {
+#ifdef __APPLE__
+  /// https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare_three_way
+  template <class I1, class I2, class Cmp>
+  constexpr auto lexicographical_compare_three_way(
+      I1 f1, I1 l1, I2 f2, I2 l2, Cmp comp) -> decltype(comp(*f1, *f2)) {
+    using ret_t = decltype(comp(*f1, *f2));
+    static_assert(
+        std::disjunction_v<std::is_same<ret_t, std::strong_ordering>,
+                           std::is_same<ret_t, std::weak_ordering>,
+                           std::is_same<ret_t, std::partial_ordering>>,
+        "The return type must be a comparison category type.");
+
+    bool exhaust1 = (f1 == l1);
+    bool exhaust2 = (f2 == l2);
+    for (; !exhaust1 && !exhaust2;
+         exhaust1 = (++f1 == l1), exhaust2 = (++f2 == l2)) {
+      if (auto c = comp(*f1, *f2); c != 0) {
+        return c;
+      }
+    }
+
+    return !exhaust1 ? std::strong_ordering::greater
+         : !exhaust2 ? std::strong_ordering::less
+                     : std::strong_ordering::equal;
+  }
+
+#if !defined(__cpp_lib_three_way_comparison)
+  // primarily fix for AppleClang < 15
+
+  // clang-format off
+  // https://github.com/llvm/llvm-project/blob/main/libcxx/include/__compare/compare_three_way.h
+  struct _LIBCPP_TEMPLATE_VIS compare_three_way
+  {
+    template<class _T1, class _T2>
+    constexpr _LIBCPP_HIDE_FROM_ABI
+    auto operator()(_T1&& __t, _T2&& __u) const
+    noexcept(noexcept(_VSTD::forward<_T1>(__t) <=> _VSTD::forward<_T2>(__u)))
+    { return          _VSTD::forward<_T1>(__t) <=> _VSTD::forward<_T2>(__u); }
+
+    using is_transparent = void;
+  };
+  // clang-format on
+#else
+  using std::compare_three_way;
+#endif
+
+  template <class I1, class I2>
+  constexpr auto lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2) {
+    return ::libp2p::cxx20::lexicographical_compare_three_way(
+        f1, l1, f2, l2, compare_three_way{});
+  }
+#else
+  using std::lexicographical_compare_three_way;
+#endif
+}  // namespace libp2p::cxx20

--- a/src/qtils/cxx20/lexicographical_compare_three_way.hpp
+++ b/src/qtils/cxx20/lexicographical_compare_three_way.hpp
@@ -13,17 +13,16 @@
 #include <algorithm>
 #endif
 
-namespace libp2p::cxx20 {
+namespace qtils::cxx20 {
 #ifdef __APPLE__
   /// https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare_three_way
   template <class I1, class I2, class Cmp>
   constexpr auto lexicographical_compare_three_way(
       I1 f1, I1 l1, I2 f2, I2 l2, Cmp comp) -> decltype(comp(*f1, *f2)) {
     using ret_t = decltype(comp(*f1, *f2));
-    static_assert(
-        std::disjunction_v<std::is_same<ret_t, std::strong_ordering>,
-                           std::is_same<ret_t, std::weak_ordering>,
-                           std::is_same<ret_t, std::partial_ordering>>,
+    static_assert(std::disjunction_v<std::is_same<ret_t, std::strong_ordering>,
+                      std::is_same<ret_t, std::weak_ordering>,
+                      std::is_same<ret_t, std::partial_ordering>>,
         "The return type must be a comparison category type.");
 
     bool exhaust1 = (f1 == l1);
@@ -36,7 +35,7 @@ namespace libp2p::cxx20 {
     }
 
     return !exhaust1 ? std::strong_ordering::greater
-         : !exhaust2 ? std::strong_ordering::less
+        : !exhaust2  ? std::strong_ordering::less
                      : std::strong_ordering::equal;
   }
 
@@ -62,10 +61,10 @@ namespace libp2p::cxx20 {
 
   template <class I1, class I2>
   constexpr auto lexicographical_compare_three_way(I1 f1, I1 l1, I2 f2, I2 l2) {
-    return ::libp2p::cxx20::lexicographical_compare_three_way(
+    return ::qtils::cxx20::lexicographical_compare_three_way(
         f1, l1, f2, l2, compare_three_way{});
   }
 #else
   using std::lexicographical_compare_three_way;
 #endif
-}  // namespace libp2p::cxx20
+}  // namespace qtils::cxx20

--- a/src/qtils/enum_error_code.hpp
+++ b/src/qtils/enum_error_code.hpp
@@ -38,14 +38,14 @@ namespace qtils {
   }
 #define Q_ENUM_ERROR_CODE(E) \
   _Q_MAKE_ERROR_CODE(E)      \
-  inline auto errorCodeMessage(const E &e)
+  inline auto errorCodeMessage(E e)
 
 // - - - - - - -
 // compatibility
 // v v v v v v v
 
 #define _OUTCOME_ERROR_CODE_MESSAGE(E, ns, e) \
-  std::string ns errorCodeMessage(const E &e)
+  std::string ns errorCodeMessage(E e)
 #define OUTCOME_HPP_DECLARE_ERROR(ns, E) \
   namespace ns {                         \
     _Q_MAKE_ERROR_CODE(E)                \

--- a/src/qtils/enum_error_code.hpp
+++ b/src/qtils/enum_error_code.hpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <system_error>
+
+template <typename E>
+  requires(requires { errorCodeMessage(E{}); })
+struct std::is_error_code_enum<E> : std::true_type {};
+
+namespace qtils {
+  template <typename E>
+  class EnumErrorCategory : public std::error_category {
+   public:
+    const char *name() const noexcept final {
+      return typeid(E).name();
+    }
+    std::string message(int code) const final {
+      return errorCodeMessage(static_cast<E>(code));
+    }
+    static const EnumErrorCategory<E> &get() {
+      static const EnumErrorCategory<E> category;
+      return category;
+    }
+
+   private:
+    EnumErrorCategory() = default;
+  };
+}  // namespace qtils
+
+#define _Q_MAKE_ERROR_CODE(E)                                           \
+  inline std::error_code make_error_code(const E &e) {                  \
+    return {static_cast<int>(e), ::qtils::EnumErrorCategory<E>::get()}; \
+  }
+#define _Q_ERROR_CODE_MESSAGE(E, ns, e) auto ns errorCodeMessage(const E &e)
+#define Q_ENUM_ERROR_CODE(E) \
+  _Q_MAKE_ERROR_CODE(E)      \
+  inline _Q_ERROR_CODE_MESSAGE(E, , e)
+
+// - - - - - - -
+// compatibility
+// v v v v v v v
+
+#define OUTCOME_HPP_DECLARE_ERROR(ns, E) \
+  namespace ns {                         \
+    _Q_MAKE_ERROR_CODE(E)                \
+    _Q_ERROR_CODE_MESSAGE(E, , );        \
+  }
+#define OUTCOME_CPP_DEFINE_CATEGORY(ns, E, e) _Q_ERROR_CODE_MESSAGE(E, ns::, e)

--- a/src/qtils/enum_error_code.hpp
+++ b/src/qtils/enum_error_code.hpp
@@ -36,18 +36,20 @@ namespace qtils {
   inline std::error_code make_error_code(const E &e) {                  \
     return {static_cast<int>(e), ::qtils::EnumErrorCategory<E>::get()}; \
   }
-#define _Q_ERROR_CODE_MESSAGE(E, ns, e) auto ns errorCodeMessage(const E &e)
 #define Q_ENUM_ERROR_CODE(E) \
   _Q_MAKE_ERROR_CODE(E)      \
-  inline _Q_ERROR_CODE_MESSAGE(E, , e)
+  inline auto errorCodeMessage(const E &e)
 
 // - - - - - - -
 // compatibility
 // v v v v v v v
 
+#define _OUTCOME_ERROR_CODE_MESSAGE(E, ns, e) \
+  std::string ns errorCodeMessage(const E &e)
 #define OUTCOME_HPP_DECLARE_ERROR(ns, E) \
   namespace ns {                         \
     _Q_MAKE_ERROR_CODE(E)                \
-    _Q_ERROR_CODE_MESSAGE(E, , );        \
+    _OUTCOME_ERROR_CODE_MESSAGE(E, , );  \
   }
-#define OUTCOME_CPP_DEFINE_CATEGORY(ns, E, e) _Q_ERROR_CODE_MESSAGE(E, ns::, e)
+#define OUTCOME_CPP_DEFINE_CATEGORY(ns, E, e) \
+  _OUTCOME_ERROR_CODE_MESSAGE(E, ns::, e)

--- a/src/qtils/enum_error_code.hpp
+++ b/src/qtils/enum_error_code.hpp
@@ -36,9 +36,11 @@ namespace qtils {
   inline std::error_code make_error_code(const E &e) {                  \
     return {static_cast<int>(e), ::qtils::EnumErrorCategory<E>::get()}; \
   }
-#define Q_ENUM_ERROR_CODE(E) \
-  _Q_MAKE_ERROR_CODE(E)      \
-  inline auto errorCodeMessage(E e)
+#define _Q_ENUM_ERROR_CODE(friend_, E) \
+  friend_ _Q_MAKE_ERROR_CODE(E)        \
+  friend_ inline auto errorCodeMessage(E e)
+#define Q_ENUM_ERROR_CODE(E) _Q_ENUM_ERROR_CODE(, E)
+#define Q_ENUM_ERROR_CODE_FRIEND(E) _Q_ENUM_ERROR_CODE(friend, E)
 
 // - - - - - - -
 // compatibility
@@ -46,10 +48,15 @@ namespace qtils {
 
 #define _OUTCOME_ERROR_CODE_MESSAGE(E, ns, e) \
   std::string ns errorCodeMessage(E e)
+#define _OUTCOME_HPP_DECLARE_ERROR(friend_, E) \
+  friend_ _Q_MAKE_ERROR_CODE(E)                \
+  friend_ _OUTCOME_ERROR_CODE_MESSAGE(E, , );
+#define OUTCOME_HPP_DECLARE_ERROR_1(E) _OUTCOME_HPP_DECLARE_ERROR(, E)
+#define OUTCOME_HPP_DECLARE_ERROR_FRIEND(E) \
+  _OUTCOME_HPP_DECLARE_ERROR(friend, E)
 #define OUTCOME_HPP_DECLARE_ERROR(ns, E) \
   namespace ns {                         \
-    _Q_MAKE_ERROR_CODE(E)                \
-    _OUTCOME_ERROR_CODE_MESSAGE(E, , );  \
+    _OUTCOME_HPP_DECLARE_ERROR(, E)      \
   }
 #define OUTCOME_CPP_DEFINE_CATEGORY(ns, E, e) \
   _OUTCOME_ERROR_CODE_MESSAGE(E, ns::, e)

--- a/src/qtils/error.hpp
+++ b/src/qtils/error.hpp
@@ -110,6 +110,11 @@ namespace qtils::error {
       return std::nullopt;
     }
 
+    template <IsEnum E>
+    bool ec(E e) const {
+      return ec<E>() == e;
+    }
+
    protected:
     std::any error_;
     fmt::format_context::iterator (*error_format_)(
@@ -121,6 +126,23 @@ namespace qtils::error {
 
   struct Errors {
     Errors(Error error) : v{std::move(error)} {}
+
+    template <typename F>
+    auto find(const F &f) const {
+      auto it = std::find_if(v.begin(), v.end(), f);
+      return it == v.end() ? std::nullopt : std::make_optional(it);
+    }
+
+    template <typename F>
+    auto find(const F &f) {
+      auto it = std::find_if(v.begin(), v.end(), f);
+      return it == v.end() ? std::nullopt : std::make_optional(it);
+    }
+
+    template <IsEnum E>
+    bool ec(E e) const {
+      return find([&](const Error &error) { return error.ec(e); }).has_value();
+    }
 
     std::deque<Error> v;
   };

--- a/src/qtils/error.hpp
+++ b/src/qtils/error.hpp
@@ -56,7 +56,7 @@ namespace qtils::error {
 
   class Error {
    public:
-    Error(const ErrorLocation &location, nullptr_t)
+    Error(const ErrorLocation &location, std::nullptr_t)
         : error_format_{nullptr}, location_{location} {}
     Error(const ErrorLocation &location, const char *error)
         : error_{error},

--- a/src/qtils/error.hpp
+++ b/src/qtils/error.hpp
@@ -9,7 +9,6 @@
 #include <any>
 #include <cstdint>
 #include <deque>
-#include <ranges>
 #include <system_error>
 
 #include <fmt/format.h>
@@ -185,9 +184,19 @@ struct fmt::formatter<qtils::Errors> {
     return ctx.begin();
   }
   static auto format(const qtils::Errors &errors, format_context &ctx) {
-    auto r = errors.v | std::views::filter([](const qtils::Error &e) {
-      return not e.isNull();
-    });
-    return fmt::format_to(ctx.out(), "{}", fmt::join(r, "; "));
+    auto out = ctx.out();
+    bool first = true;
+    for (auto &error : errors.v) {
+      if (error.isNull()) {
+        continue;
+      }
+      if (first) {
+        first = false;
+      } else {
+        out = fmt::detail::write(out, "; ");
+      }
+      out = fmt::format_to(out, "{}", error);
+    }
+    return out;
   }
 };

--- a/src/qtils/error.hpp
+++ b/src/qtils/error.hpp
@@ -94,8 +94,13 @@ namespace qtils::error {
       return std::any_cast<T>(&error_);
     }
 
+    template <typename T>
+    OptRef<const T> as() const {
+      return std::any_cast<T>(&error_);
+    }
+
     template <IsEnum E>
-    std::optional<E> ec() {
+    std::optional<E> ec() const {
       if (auto ec = as<std::error_code>()) {
         static auto &category = make_error_code(E{}).category();
         if (ec->category() == category) {

--- a/src/qtils/error.hpp
+++ b/src/qtils/error.hpp
@@ -52,7 +52,7 @@ namespace qtils::error {
    public:
     Error(const ErrorLocation &location, const char *error)
         : error_{error},
-          error_format_{+[](fmt::format_context &ctx, const std::any &error) {
+          error_format_{[](fmt::format_context &ctx, const std::any &error) {
             return fmt::format_to(
                 ctx.out(), "{}", std::any_cast<const char *>(error));
           }},
@@ -61,7 +61,7 @@ namespace qtils::error {
     Error(const ErrorLocation &location, E error)
       requires(not MakeErrorCode<E>)
         : error_{error},
-          error_format_{+[](fmt::format_context &ctx, const std::any &any) {
+          error_format_{[](fmt::format_context &ctx, const std::any &any) {
             auto &error = std::any_cast<const E &>(any);
             if constexpr (fmt::is_formattable<E>::value) {
               return fmt::format_to(ctx.out(), "{}", error);
@@ -75,7 +75,7 @@ namespace qtils::error {
         : Error{location, make_error_code(error)} {}
     Error(const ErrorLocation &location, const std::error_code &error)
         : error_{error},
-          error_format_{+[](fmt::format_context &ctx, const std::any &any) {
+          error_format_{[](fmt::format_context &ctx, const std::any &any) {
             return [&](auto &error) {
               if constexpr (fmt::is_formattable<std::error_code>::value) {
                 return fmt::format_to(ctx.out(), "{}", error);

--- a/src/qtils/error.hpp
+++ b/src/qtils/error.hpp
@@ -1,0 +1,142 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <any>
+#include <cstdint>
+#include <deque>
+#include <system_error>
+
+#include <fmt/format.h>
+
+#include <qtils/optref.hpp>
+
+#define Q_ERROR_LOCATION \
+  (::qtils::ErrorLocation{__PRETTY_FUNCTION__, __FILE__, __LINE__})
+
+#define Q_ERROR(error_) (::qtils::Error{Q_ERROR_LOCATION, error_})
+
+namespace qtils::error {
+  struct ErrorLocation {
+    const char *fn;
+    const char *file;
+    uint32_t line;
+  };
+
+  template <typename E>
+  concept IsEnum = std::is_enum_v<E>;
+
+  template <typename E>
+  concept MakeErrorCode = requires { make_error_code(E{}); };
+
+  template <IsEnum E>
+  fmt::format_context::iterator formatEnum(fmt::format_context &ctx, E error) {
+    return fmt::format_to(
+        ctx.out(), "{}({})", typeid(E).name(), fmt::underlying(error));
+  }
+
+  inline fmt::format_context::iterator formatEc(
+      fmt::format_context &ctx, const std::error_code &error) {
+    return fmt::format_to(ctx.out(),
+        "{}({}) {}",
+        error.category().name(),
+        error.value(),
+        error.message());
+  }
+
+  class Error {
+   public:
+    Error(const ErrorLocation &location, const char *error)
+        : error_{error},
+          error_format_{+[](fmt::format_context &ctx, const std::any &error) {
+            return fmt::format_to(
+                ctx.out(), "{}", std::any_cast<const char *>(error));
+          }},
+          location_{location} {}
+    template <IsEnum E>
+    Error(const ErrorLocation &location, E error)
+      requires(not MakeErrorCode<E>)
+        : error_{error},
+          error_format_{+[](fmt::format_context &ctx, const std::any &any) {
+            auto &error = std::any_cast<const E &>(any);
+            if constexpr (fmt::is_formattable<E>::value) {
+              return fmt::format_to(ctx.out(), "{}", error);
+            }
+            return formatEnum(ctx, error);
+          }},
+          location_{location} {}
+    template <IsEnum E>
+    Error(const ErrorLocation &location, E error)
+      requires(MakeErrorCode<E>)
+        : Error{location, make_error_code(error)} {}
+    Error(const ErrorLocation &location, const std::error_code &error)
+        : error_{error},
+          error_format_{+[](fmt::format_context &ctx, const std::any &any) {
+            return [&](auto &error) {
+              if constexpr (fmt::is_formattable<std::error_code>::value) {
+                return fmt::format_to(ctx.out(), "{}", error);
+              }
+              return formatEc(ctx, error);
+            }(std::any_cast<const std::error_code &>(any));
+          }},
+          location_{location} {}
+
+    const ErrorLocation &location() const {
+      return location_;
+    }
+
+    template <typename T>
+    OptRef<T> as() {
+      return std::any_cast<T>(&error_);
+    }
+
+    template <IsEnum E>
+    std::optional<E> ec() {
+      if (auto ec = as<std::error_code>()) {
+        static auto &category = make_error_code(E{}).category();
+        if (ec->category() == category) {
+          return static_cast<E>(ec->value());
+        }
+      }
+      return std::nullopt;
+    }
+
+   protected:
+    std::any error_;
+    fmt::format_context::iterator (*error_format_)(
+        fmt::format_context &, const std::any &);
+    ErrorLocation location_;
+
+    friend struct fmt::formatter<Error>;
+  };
+
+  struct Errors {
+    Errors(Error error) : v{std::move(error)} {}
+
+    std::deque<Error> v;
+  };
+
+  inline auto make_exception_ptr(const Errors &errors) {
+    return std::make_exception_ptr(errors);
+  }
+}  // namespace qtils::error
+
+namespace qtils {
+  using error::Error;
+  using error::ErrorLocation;
+  using error::Errors;
+}  // namespace qtils
+
+template <>
+struct fmt::formatter<qtils::Error> {
+  static constexpr auto parse(format_parse_context &ctx) {
+    return ctx.begin();
+  }
+  static auto format(const qtils::Error &error, format_context &ctx) {
+    return error.error_format_(ctx, error.error_);
+  }
+};

--- a/src/qtils/hex.hpp
+++ b/src/qtils/hex.hpp
@@ -1,0 +1,63 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include <qtils/bytes.hpp>
+
+template <>
+struct fmt::formatter<qtils::BytesIn> {
+  bool prefix = true;
+  bool full = false;
+  constexpr auto parse(format_parse_context &ctx) {
+    auto it = ctx.begin();
+    auto end = [&] { return it == ctx.end() or *it == '}'; };
+    if (end()) {
+      return it;
+    }
+    if (*it == 'x') {
+      ++it;
+      prefix = false;
+      full = true;
+      if (end()) {
+        return it;
+      }
+    } else if (*it == '0') {
+      ++it;
+      prefix = true;
+      if (not end() and *it == 'x') {
+        ++it;
+        full = true;
+        if (end()) {
+          return it;
+        }
+      }
+    }
+    fmt::throw_format_error("\"x\" or \"0x\" expected");
+  }
+  auto format(const qtils::BytesIn bytes, format_context &ctx) const {
+    auto out = ctx.out();
+    if (prefix) {
+      out = fmt::format_to(out, "0x");
+    }
+    constexpr size_t kHead = 2, kTail = 2, kSmall = 1;
+    if (full or bytes.size() <= kHead + kTail + kSmall) {
+      return fmt::format_to(out, "{:02x}", fmt::join(bytes, ""));
+    }
+    return fmt::format_to(out,
+        "{:02x}…{:02x}",
+        fmt::join(bytes.first(kHead), ""),
+        fmt::join(bytes.last(kTail), ""));
+  }
+};
+template <>
+struct fmt::formatter<qtils::Bytes> : fmt::formatter<qtils::BytesIn> {};
+template <size_t N>
+struct fmt::formatter<qtils::BytesN<N>> : fmt::formatter<qtils::BytesIn> {};
+template <>
+struct fmt::formatter<qtils::BytesOut> : fmt::formatter<qtils::BytesIn> {};

--- a/src/qtils/hex.hpp
+++ b/src/qtils/hex.hpp
@@ -43,7 +43,7 @@ struct fmt::formatter<qtils::BytesIn> {
   auto format(const qtils::BytesIn bytes, format_context &ctx) const {
     auto out = ctx.out();
     if (prefix) {
-      out = fmt::format_to(out, "0x");
+      out = fmt::detail::write(out, "0x");
     }
     constexpr size_t kHead = 2, kTail = 2, kSmall = 1;
     if (full or bytes.size() <= kHead + kTail + kSmall) {

--- a/src/qtils/hex.hpp
+++ b/src/qtils/hex.hpp
@@ -40,7 +40,7 @@ struct fmt::formatter<qtils::BytesIn> {
     }
     fmt::throw_format_error("\"x\" or \"0x\" expected");
   }
-  auto format(const qtils::BytesIn bytes, format_context &ctx) const {
+  auto format(const qtils::BytesIn &bytes, format_context &ctx) const {
     auto out = ctx.out();
     if (prefix) {
       out = fmt::detail::write(out, "0x");

--- a/src/qtils/move.hpp
+++ b/src/qtils/move.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <utility>
+
+namespace qtils {
+  /**
+   * Used to reset `std::coroutine_handle` on move.
+   */
+  template <typename T>
+  struct MoveOnly {
+    MoveOnly() : v{} {};
+    MoveOnly(T &&v) : v{std::move(v)} {}
+    MoveOnly(const MoveOnly &other) = delete;
+    MoveOnly(MoveOnly &&other) : v{std::move(other.v)} {
+      other.v = T();
+    }
+    MoveOnly &operator=(const MoveOnly &other) = delete;
+    MoveOnly &operator=(MoveOnly &&other) {
+      v = std::move(other.v);
+      other.v = T();
+      return *this;
+    }
+    T v;
+  };
+
+  /**
+   * Used by `OptRef` to reset `T *` on move.
+   */
+  template <typename T>
+  struct MoveCopy {
+    MoveCopy() : v{} {};
+    MoveCopy(const T &v) : v{v} {}
+    MoveCopy(T &&v) : v{std::move(v)} {}
+    MoveCopy(const MoveCopy &other) = default;
+    MoveCopy(MoveCopy &&other) : v{std::move(other.v)} {
+      other.v = T();
+    }
+    MoveCopy &operator=(const MoveCopy &other) = default;
+    MoveCopy &operator=(MoveCopy &&other) {
+      v = std::move(other.v);
+      other.v = T();
+      return *this;
+    }
+    T v;
+  };
+}  // namespace qtils

--- a/src/qtils/optref.hpp
+++ b/src/qtils/optref.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <qtils/move.hpp>
+
+namespace qtils {
+  /**
+   * - `T *`
+   * - `std::optional<std::reference_wrapper<T>>`
+   */
+  template <typename T>
+  class OptRef {
+   public:
+    OptRef() = default;
+    OptRef(T *ptr) : ptr_{ptr} {}
+    template <typename U>
+    OptRef(U other)
+      requires std::is_const_v<T>
+        and std::is_same_v<U, OptRef<std::remove_const_t<T>>>
+        : ptr_{std::move(other.ptr_.v)} {}
+
+    operator bool() const {
+      return ptr_.v != nullptr;
+    }
+    T &operator*() const {
+      if (ptr_.v == nullptr) {
+        throw std::bad_optional_access{};
+      }
+      return *ptr_.v;
+    }
+    T *operator->() const {
+      if (ptr_.v == nullptr) {
+        throw std::bad_optional_access{};
+      }
+      return ptr_.v;
+    }
+
+   protected:
+    MoveCopy<T *> ptr_;
+
+    template <typename U>
+    friend class OptRef;
+  };
+}  // namespace qtils

--- a/src/qtils/outcome.hpp
+++ b/src/qtils/outcome.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/outcome/result.hpp>
+
+#include <qtils/error.hpp>
+
+#define _OUTCOME_UNIQUE_2(x, y) x##y
+#define _OUTCOME_UNIQUE(x, y) _OUTCOME_UNIQUE_2(x, y)
+#define OUTCOME_UNIQUE _OUTCOME_UNIQUE(outcome_unique_, __COUNTER__)
+
+#define _Q_TRY_void(tmp, cb, expr, error_) \
+  auto &&tmp = expr;                       \
+  if (tmp.has_error()) {                   \
+    tmp.error().v.emplace_front(error_);   \
+    return cb(std::move(tmp).error());     \
+  }
+#define _Q_TRY_out(tmp, cb, out, expr, error) \
+  _Q_TRY_void(tmp, cb, expr, error) out = std::move(tmp).value()
+#define Q_TRYV(expr, error) _Q_TRY_void(OUTCOME_UNIQUE, , expr, error)
+#define Q_TRY(out, expr, error) _Q_TRY_out(OUTCOME_UNIQUE, , out, expr, error)
+#define Q_CB_TRYV(cb, expr, error) _Q_TRY_void(OUTCOME_UNIQUE, cb, expr, error)
+#define Q_CB_TRY(cb, out, expr, error) \
+  _Q_TRY_out(OUTCOME_UNIQUE, cb, out, expr, error)
+
+namespace qtils {
+  template <class R>
+  using Outcome = boost::outcome_v2::basic_result<R,
+      Errors,
+      boost::outcome_v2::policy::default_policy<R, Errors, void>>;
+}  // namespace qtils
+
+// - - - - - - -
+// compatibility
+// v v v v v v v
+
+#define _OUTCOME_TRY_void(tmp, expr) \
+  _Q_TRY_void(tmp, , expr, Q_ERROR("OUTCOME_TRY"))
+#define _BOOST_OUTCOME_TRY(tmp, out, expr) \
+  _OUTCOME_TRY_void(tmp, expr) out = std::move(tmp).value()
+#define _OUTCOME_TRY_out(tmp, out, expr) \
+  _BOOST_OUTCOME_TRY(tmp, auto &&out, expr)
+#define BOOST_OUTCOME_TRY(out, expr) \
+  _BOOST_OUTCOME_TRY(OUTCOME_UNIQUE, out, expr)
+#define _OUTCOME_OVERLOAD(_1, _2, s, ...) _OUTCOME_TRY_##s
+#define OUTCOME_TRY(...) \
+  _OUTCOME_OVERLOAD(__VA_ARGS__, out, void)(OUTCOME_UNIQUE, __VA_ARGS__)
+
+namespace outcome {
+  template <class R>
+  using result = qtils::Outcome<R>;
+  using boost::outcome_v2::success;
+}  // namespace outcome

--- a/src/qtils/outcome.hpp
+++ b/src/qtils/outcome.hpp
@@ -39,8 +39,7 @@ namespace qtils {
 // compatibility
 // v v v v v v v
 
-#define _OUTCOME_TRY_void(tmp, expr) \
-  _Q_TRY_void(tmp, , expr, Q_ERROR("OUTCOME_TRY"))
+#define _OUTCOME_TRY_void(tmp, expr) _Q_TRY_void(tmp, , expr, Q_ERROR(nullptr))
 #define _BOOST_OUTCOME_TRY(tmp, out, expr) \
   _OUTCOME_TRY_void(tmp, expr) out = std::move(tmp).value()
 #define _OUTCOME_TRY_out(tmp, out, expr) \

--- a/src/qtils/unhex.hpp
+++ b/src/qtils/unhex.hpp
@@ -52,7 +52,7 @@ namespace qtils {
     return t;
   }
 
-  auto operator""_unhex(const char *c, size_t s) {
+  inline auto operator""_unhex(const char *c, size_t s) {
     return unhex(std::string_view{c, s}).value();
   }
 }  // namespace qtils

--- a/src/qtils/unhex.hpp
+++ b/src/qtils/unhex.hpp
@@ -51,4 +51,8 @@ namespace qtils {
     }
     return t;
   }
+
+  auto operator""_unhex(const char *c, size_t s) {
+    return unhex(std::string_view{c, s}).value();
+  }
 }  // namespace qtils

--- a/src/qtils/unhex.hpp
+++ b/src/qtils/unhex.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/algorithm/hex.hpp>
+#include <qtils/bytes.hpp>
+#include <qtils/outcome.hpp>
+
+namespace qtils {
+  enum class Unhex0x {
+    No,
+    Maybe,
+    Yes,
+  };
+  template <typename T = Bytes>
+  outcome::result<T> unhex(
+      std::string_view s, Unhex0x want_prefix = Unhex0x::Maybe) {
+    constexpr std::string_view kPrefix{"0x"};
+    auto has_prefix = s.starts_with(kPrefix);
+    if (has_prefix) {
+      if (want_prefix == Unhex0x::No) {
+        return Q_ERROR("unhex: \"0x\" prefix not allowed");
+      }
+      s.remove_prefix(kPrefix.size());
+    } else if (want_prefix == Unhex0x::Yes) {
+      return Q_ERROR("unhex: \"0x\" prefix required");
+    }
+    if (s.size() % 2 != 0) {
+      return Q_ERROR("unhex: even length string required");
+    }
+    auto count = s.size() / 2;
+    T t;
+    if constexpr (requires(T t) { t.resize(size_t{}); }) {
+      t.resize(count);
+    } else {
+      if (count < t.size()) {
+        return Q_ERROR("unhex: string too short");
+      }
+      if (count > t.size()) {
+        return Q_ERROR("unhex: string too long");
+      }
+    }
+    try {
+      boost::algorithm::unhex(s.begin(), s.end(), t.begin());
+    } catch (const boost::algorithm::non_hex_input &) {
+      return Q_ERROR("unhex: hex string expected");
+    }
+    return t;
+  }
+}  // namespace qtils


### PR DESCRIPTION
- https://github.com/qdrvm/kagome/issues/1813
- `Outcome<T>`, `Errors`, `Error`, `Q_ERROR`, `Q_TRY`
  - `outcome::result<T>`, `OUTCOME_TRY`
- `OptRef<T>`
- (libp2p) `Bytes`, `BytesN<N>`, `BytesIn`, `BytesOut`
- (hexutil) fmt `"{}" = "0x0102…0506"`, `"{:x}" = "010203040506"`, `"{:0x}" = "0x010203040506"`