### PR TITLE
hex, unhex, bytestr

### DIFF
--- a/src/qtils/append.hpp
+++ b/src/qtils/append.hpp
@@ -1,0 +1,18 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cstring>
+#include <qtils/bytes.hpp>
+
+namespace qtils {
+  inline void append(Bytes &l, BytesIn r) {
+    auto offset = l.size();
+    l.resize(offset + r.size());
+    memcpy(l.data() + offset, r.data(), r.size());
+  }
+}  // namespace qtils

--- a/src/qtils/bytes.hpp
+++ b/src/qtils/bytes.hpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace qtils {
+  using Bytes = std::vector<uint8_t>;
+  template <size_t N>
+  using BytesN = std::array<uint8_t, N>;
+  using BytesIn = std::span<const uint8_t>;
+  using BytesOut = std::span<uint8_t>;
+}  // namespace qtils

--- a/src/qtils/bytestr.hpp
+++ b/src/qtils/bytestr.hpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include <qtils/bytes.hpp>
+
+namespace qtils {
+  inline BytesIn str2byte(std::span<const char> s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {reinterpret_cast<const uint8_t *>(s.data()), s.size()};
+  }
+
+  inline std::string_view byte2str(const BytesIn &s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {reinterpret_cast<const char *>(s.data()), s.size()};
+  }
+}  // namespace qtils

--- a/src/qtils/bytestr.hpp
+++ b/src/qtils/bytestr.hpp
@@ -11,13 +11,35 @@
 #include <qtils/bytes.hpp>
 
 namespace qtils {
-  inline BytesIn str2byte(std::span<const char> s) {
+  inline const uint8_t *str2byte(const char *s) {
     // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    return {reinterpret_cast<const uint8_t *>(s.data()), s.size()};
+    return reinterpret_cast<const uint8_t *>(s);
+  }
+
+  inline const char *byte2str(const uint8_t *s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<const char *>(s);
+  }
+
+  inline uint8_t *str2byte(char *s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<uint8_t *>(s);
+  }
+
+  inline char *byte2str(uint8_t *s) {
+    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<char *>(s);
+  }
+
+  inline BytesIn str2byte(std::span<const char> s) {
+    return {str2byte(s.data()), s.size()};
   }
 
   inline std::string_view byte2str(const BytesIn &s) {
-    // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-    return {reinterpret_cast<const char *>(s.data()), s.size()};
+    return {byte2str(s.data()), s.size()};
+  }
+
+  inline BytesOut str2byte(std::span<char> s) {
+    return {str2byte(s.data()), s.size()};
   }
 }  // namespace qtils

--- a/src/qtils/hex.hpp
+++ b/src/qtils/hex.hpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <fmt/format.h>
+
+#include <qtils/bytes.hpp>
+
+template <>
+struct fmt::formatter<qtils::BytesIn> {
+  bool prefix = true;
+  bool full = false;
+  bool lower = true;
+  constexpr auto parse(format_parse_context &ctx) {
+    auto it = ctx.begin();
+    auto end = [&] { return it == ctx.end() or *it == '}'; };
+    if (end()) {
+      return it;
+    }
+    prefix = *it == '0';
+    if (prefix) {
+      ++it;
+    }
+    if (not end()) {
+      lower = *it == 'x';
+      if (lower or *it == 'X') {
+        ++it;
+        full = true;
+        if (end()) {
+          return it;
+        }
+      }
+    }
+    fmt::throw_format_error("\"x\"/\"X\" or \"0x\"/\"0X\" expected");
+  }
+  auto format(const qtils::BytesIn &bytes, format_context &ctx) const {
+    auto out = ctx.out();
+    if (prefix) {
+      out = fmt::detail::write(out, "0x");
+    }
+    constexpr size_t kHead = 2, kTail = 2, kSmall = 1;
+    if (full or bytes.size() <= kHead + kTail + kSmall) {
+      return lower ? fmt::format_to(out, "{:02x}", fmt::join(bytes, ""))
+                   : fmt::format_to(out, "{:02X}", fmt::join(bytes, ""));
+    }
+    return fmt::format_to(out,
+        "{:02x}…{:02x}",
+        fmt::join(bytes.first(kHead), ""),
+        fmt::join(bytes.last(kTail), ""));
+  }
+};
+template <>
+struct fmt::formatter<qtils::Bytes> : fmt::formatter<qtils::BytesIn> {};
+template <size_t N>
+struct fmt::formatter<qtils::BytesN<N>> : fmt::formatter<qtils::BytesIn> {};
+template <>
+struct fmt::formatter<qtils::BytesOut> : fmt::formatter<qtils::BytesIn> {};

--- a/src/qtils/unhex.hpp
+++ b/src/qtils/unhex.hpp
@@ -1,0 +1,83 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <boost/algorithm/hex.hpp>
+#include <qtils/bytes.hpp>
+#include <qtils/enum_error_code.hpp>
+#include <qtils/outcome.hpp>
+
+namespace qtils {
+  enum class UnhexError {
+    UNEXPECTED_0X,
+    REQUIRED_0X,
+    ODD_LENGTH,
+    TOO_SHORT,
+    TOO_LONG,
+    NON_HEX,
+  };
+  Q_ENUM_ERROR_CODE(UnhexError) {
+    using E = decltype(e);
+    switch (e) {
+      case E::UNEXPECTED_0X:
+        return "UNEXPECTED_0X";
+      case E::REQUIRED_0X:
+        return "REQUIRED_0X";
+      case E::ODD_LENGTH:
+        return "ODD_LENGTH";
+      case E::TOO_SHORT:
+        return "TOO_SHORT";
+      case E::TOO_LONG:
+        return "TOO_LONG";
+      case E::NON_HEX:
+        return "NON_HEX";
+    }
+    abort();
+  }
+
+  template <typename T = Bytes>
+  outcome::result<T> unhex(std::string_view s) {
+    if (s.starts_with("0x")) {
+      return UnhexError::UNEXPECTED_0X;
+    }
+    if (s.size() % 2 != 0) {
+      return UnhexError::ODD_LENGTH;
+    }
+    auto count = s.size() / 2;
+    T t;
+    if constexpr (requires(T t) { t.resize(size_t{}); }) {
+      t.resize(count);
+    } else {
+      if (count < t.size()) {
+        return UnhexError::TOO_SHORT;
+      }
+      if (count > t.size()) {
+        return UnhexError::TOO_LONG;
+      }
+    }
+    try {
+      boost::algorithm::unhex(s.begin(), s.end(), t.begin());
+    } catch (const boost::algorithm::non_hex_input &) {
+      return UnhexError::NON_HEX;
+    }
+    return t;
+  }
+
+  template <typename T = Bytes>
+  outcome::result<T> unhex0x(std::string_view s, bool optional_0x = false) {
+    if (s.starts_with("0x")) {
+      s.remove_prefix(2);
+    } else if (not optional_0x) {
+      return UnhexError::REQUIRED_0X;
+    }
+    return unhex<T>(s);
+  }
+
+  inline auto operator""_unhex(const char *c, size_t s) {
+    return unhex(std::string_view{c, s}).value();
+  }
+}  // namespace qtils


### PR DESCRIPTION
- bytes hex fmt `"{}" = "0x0102…0506"`, `"{:x}" = "010203040506"`, `"{:0x}" = "0x010203040506"` (`X` for uppercase)
- `unhex(s)`, `unhex0x(s, optional_0x=false)`, `operator""_unhex`
- (libp2p) `Bytes`, `BytesN<N>`, `BytesIn`, `BytesOut`
- `append(Bytes, BytesIn)`
- `byte2str`, `str2byte`, to convert bytes/string (binary strings like protobuf)